### PR TITLE
Document what the CLI is used for and what it is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Fastmigrate implements the standard database migration pattern, so the key conce
 
 ### Command-line Usage
 
-The fastmigrate command-line tool runs developer-written migrations but doesn't include the full library functionality. It only adds versioning to new databases; for existing databases, developers must implement modifications separately outside of the CLI.
-
-To familiarize yourself with its action, or in development, you might want to run `fastmigrate` from the command line. 
+To familiarize yourself with its action, or in development, you might want to run fastmigrate from the command line.
 
 When you run `fastmigrate`, it will look for migration scripts in `./migrations/` and a database at `./data/database.db`. These values can also be overridden by CLI arguments or by values set in the `.fastmigrate` configuration file, which is in ini format.
 
@@ -82,6 +80,15 @@ When you run `fastmigrate`, it will look for migration scripts in `./migrations/
    ```
    Creates a timestamped backup of the database before running any migrations.
    The backup file will be named `database.db.YYYYMMDD_HHMMSS.backup`.
+
+
+
+> [!NOTE]  
+> fastmigrate is not currently able to add versioning to a database already in use -- to do that, run this in python
+> ```python
+> from fastmigrate import ensure_meta_table
+> ensure_meta_table(path/to/db)
+> ```
 
 ### Unversioned Databases
 


### PR DESCRIPTION
The PR addresses makes it clear that the CLI isn't meant for generating migrations in any language including SQL, python, or bash script. This includes converting an existing database to be fastmigrate-friendly.

Those actions should be coded directly by the developer.