### PR TITLE
Update CLI to exit on backup failure

### DIFF
--- a/fastmigrate/cli.py
+++ b/fastmigrate/cli.py
@@ -132,7 +132,8 @@ def main(
     
     # Create a backup if requested
     if backup and os.path.exists(db_path):
-        create_database_backup(db_path)
+        if create_database_backup(db_path) is None:
+            sys.exit(1)
     
     # Run migrations with verbose=True for CLI usage
     success = run_migrations(db_path, migrations_path, verbose=True)

--- a/fastmigrate/core.py
+++ b/fastmigrate/core.py
@@ -280,7 +280,7 @@ def execute_shell_script(db_path: str, script_path: str) -> bool:
         return False
 
 
-def create_database_backup(db_path: str) -> str:
+def create_database_backup(db_path: str) -> str | None:
     """Create a backup of the SQLite database file using SQLite's built-in backup command.
     
     Uses the '.backup' SQLite command which ensures a consistent backup even if the
@@ -295,7 +295,7 @@ def create_database_backup(db_path: str) -> str:
     # Only proceed if the database exists
     if not os.path.exists(db_path):
         console.print(f"[yellow]Warning:[/yellow] Database file does not exist: {db_path}")
-        return ""
+        return None
         
     # Create a timestamped backup filename
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -327,7 +327,7 @@ def create_database_backup(db_path: str) -> str:
         return backup_path
     except Exception as e:
         console.print(f"[bold red]Error creating backup:[/bold red] {e}")
-        return ""
+        return None
 
 
 def execute_migration_script(db_path: str, script_path: str) -> bool:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,7 +235,7 @@ def test_create_database_backup():
         # Test backup of non-existent database
         non_existent_path = os.path.join(temp_dir, "nonexistent.db")
         result = create_database_backup(non_existent_path)
-        assert result == ""
+        assert result is None
 
 
 def test_run_migrations_on_unversioned_db():


### PR DESCRIPTION
This PR modifies `create_database_backup` to return None on a failure and updates the CLI to exit in backup failure instead of continuing with the migration.

Resolves #9.