### PR TITLE
CLI: enroll_db

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Here are some commands:
    ```
    Run all needed migrations on the db. Fails if a migration fails, or if there is no managed db at the path. This is equivalent to calling `fastmigrate.run_migrations()`
 
+5. **Enroll an existing db**:
+   ```
+   fastmigrate_enroll_db --db path/to/data.db
+   ```
+   This will generate an initial migration of the specified data called `0001-initial.sql`, then enroll the database into fastmigrate's versioning system, and will finally set the version to 1. 
 
 ### How to enroll an existing, unversioned database into fastmigrate
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here are some commands:
    ```
    fastmigrate_enroll_db --db path/to/data.db
    ```
-   This will generate an initial migration of the specified data called `0001-initial.sql`, then enroll the database into fastmigrate's versioning system, and will finally set the version to 1. 
+   Enroll an existing SQLite database for versioning, adding a default initial migration called `0001-initial.sql`, then running it. Running the initial migration will set the version to 1. This is equivalent to calling `fastmigrate.enroll_db()`
 
 ### How to enroll an existing, unversioned database into fastmigrate
 

--- a/fastmigrate/cli.py
+++ b/fastmigrate/cli.py
@@ -129,6 +129,28 @@ def create_db(
         sys.exit(1)
 
 @call_parse
+def enroll_db(
+    db: Path = DEFAULT_DB, # Path to the SQLite database file
+    migrations: Path = DEFAULT_MIGRATIONS, # Path to the migrations directory
+    config_path: Path = DEFAULT_CONFIG # Path to config file
+) -> None:
+    """Enroll an existing SQLite database for versioning.
+
+    Note: command line arguments take precedence over values from a
+    config file, unless they are equal to default values.
+    """
+    db_path, migrations_path = _get_config(config_path, db, migrations)
+    if not migrations_path.exists(): migrations_path.mkdir(parents=True)
+    initial_migration = migrations_path / "0001-initial.sql"
+    schema = core.get_db_schema(db_path)    
+    initial_migration.write_text(schema)    
+    core._ensure_meta_table(db_path)
+    success = core.run_migrations(db_path, migrations_path, verbose=True)    
+    if not success:
+        sys.exit(1)
+
+
+@call_parse
 def run_migrations(
     db: Path = DEFAULT_DB, # Path to the SQLite database file
     migrations: Path = DEFAULT_MIGRATIONS, # Path to the migrations directory

--- a/fastmigrate/cli.py
+++ b/fastmigrate/cli.py
@@ -134,7 +134,7 @@ def enroll_db(
     migrations: Path = DEFAULT_MIGRATIONS, # Path to the migrations directory
     config_path: Path = DEFAULT_CONFIG # Path to config file
 ) -> None:
-    """Enroll an existing SQLite database for versioning.
+    """Enroll an existing SQLite database for versioning, adding a default initial migration.
 
     Note: command line arguments take precedence over values from a
     config file, unless they are equal to default values.

--- a/fastmigrate/cli.py
+++ b/fastmigrate/cli.py
@@ -134,7 +134,7 @@ def enroll_db(
     migrations: Path = DEFAULT_MIGRATIONS, # Path to the migrations directory
     config_path: Path = DEFAULT_CONFIG # Path to config file
 ) -> None:
-    """Enroll an existing SQLite database for versioning, adding a default initial migration.
+    """Enroll an existing SQLite database for versioning, adding a default initial migration, then running it.
 
     Note: command line arguments take precedence over values from a
     config file, unless they are equal to default values.

--- a/fastmigrate/core.py
+++ b/fastmigrate/core.py
@@ -101,7 +101,7 @@ def _ensure_meta_table(db_path: Path) -> None:
                         """
                     )
                     conn.execute("INSERT INTO _meta (id, version) VALUES (1, 0)")
-                    console.print('Database is enrolled')
+                    print('Database is enrolled')
             except sqlite3.Error as e:
                 raise sqlite3.Error(f"Failed to create _meta table: {e}")
     except sqlite3.Error as e:

--- a/fastmigrate/core.py
+++ b/fastmigrate/core.py
@@ -98,7 +98,7 @@ def _ensure_meta_table(db_path: Path) -> None:
                         """
                     )
                     conn.execute("INSERT INTO _meta (id, version) VALUES (1, 0)")
-                    console.print(f"[green]Database is enrolled[/green]")
+                    console.print('Database is enrolled')
             except sqlite3.Error as e:
                 raise sqlite3.Error(f"Failed to create _meta table: {e}")
     except sqlite3.Error as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 fastmigrate_backup_db = "fastmigrate.cli:backup_db"
 fastmigrate_check_version = "fastmigrate.cli:check_version"
 fastmigrate_create_db = "fastmigrate.cli:create_db"
+fastmigrate_enroll_db = "fastmigrate.cli:enroll_db"
 fastmigrate_run_migrations = "fastmigrate.cli:run_migrations"
 
 [tool.pytest]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,7 @@ def test_cli_precedence():
 def test_cli_enroll_db_success(tmp_path):
     """Test the CLI enroll_db command successfully enrolls an unversioned database."""
     db_path = tmp_path / "unversioned.db"
+    migrations_path = tmp_path / "migrations"
     
     # Create an unversioned database with a sample table
     conn = sqlite3.connect(db_path)
@@ -281,6 +282,7 @@ def test_cli_enroll_db_success(tmp_path):
     result = subprocess.run([
         "fastmigrate_enroll_db",
         "--db", db_path,
+        "--migrations", migrations_path,
     ], capture_output=True, text=True)
     
     assert result.returncode == 0
@@ -304,6 +306,7 @@ def test_cli_enroll_db_success(tmp_path):
 def test_cli_enroll_db_already_versioned(tmp_path):
     """Test the CLI enroll_db command fails when the database is already versioned."""
     db_path = tmp_path / "versioned.db"
+    migrations_path = tmp_path / "migrations"
     
     # Create a versioned database
     conn = sqlite3.connect(db_path)
@@ -321,6 +324,7 @@ def test_cli_enroll_db_already_versioned(tmp_path):
     result = subprocess.run([
         "fastmigrate_enroll_db",
         "--db", db_path,
+        "--migrations", migrations_path,
     ], capture_output=True, text=True)
     
     # Should exit with zero status because the database is successfully versioned
@@ -336,6 +340,7 @@ def test_cli_enroll_db_already_versioned(tmp_path):
 def test_cli_enroll_db_nonexistent_db(tmp_path):
     """Test the CLI enroll_db command fails when the database doesn't exist."""
     db_path = tmp_path / "nonexistent.db"
+    migrations_path = tmp_path / "migrations"
     
     # Verify file doesn't exist
     assert not db_path.exists()
@@ -344,6 +349,7 @@ def test_cli_enroll_db_nonexistent_db(tmp_path):
     result = subprocess.run([
         "fastmigrate_enroll_db",
         "--db", db_path,
+        "--migrations", migrations_path,
     ], capture_output=True, text=True)
     
     # Should exit with non-zero status
@@ -354,6 +360,7 @@ def test_cli_enroll_db_nonexistent_db(tmp_path):
 def test_cli_enroll_db_invalid_db(tmp_path):
     """Test the CLI enroll_db command fails when the database is invalid."""
     db_path = tmp_path / "invalid.db"
+    migrations_path = tmp_path / "migrations"
     
     # Create an invalid database file
     with open(db_path, 'wb') as f:
@@ -362,7 +369,8 @@ def test_cli_enroll_db_invalid_db(tmp_path):
     # Run the enroll_db command on an invalid database
     result = subprocess.run([
         "fastmigrate_enroll_db",
-        "--db", db_path
+        "--db", db_path,
+        "--migrations", migrations_path
     ], capture_output=True, text=True)
     
     # Should exit with non-zero status
@@ -372,6 +380,7 @@ def test_cli_enroll_db_invalid_db(tmp_path):
 def test_cli_enroll_db_with_config_file(tmp_path):
     """Test the CLI enroll_db command with configuration from a file."""
     db_path = tmp_path / "db_from_config.db"
+    migrations_path = tmp_path / "migrations"
     config_path = tmp_path / "test_config.ini"
     
     # Create an unversioned database
@@ -381,7 +390,7 @@ def test_cli_enroll_db_with_config_file(tmp_path):
     conn.close()
     
     # Create a config file
-    config_path.write_text(f"[paths]\ndb = {db_path}")
+    config_path.write_text(f"[paths]\ndb = {db_path}\nmigrations = {migrations_path}")
     
     # Run the enroll_db command with config
     result = subprocess.run([

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,19 +10,28 @@ from unittest.mock import patch
 import subprocess
 
 from fastmigrate.cli import backup_db, check_version, create_db, run_migrations
-from fastmigrate.core import _ensure_meta_table, _set_db_version
+from fastmigrate.core import _set_db_version, _ensure_meta_table
 
 # Path to the test migrations directory
 CLI_MIGRATIONS_DIR = Path(__file__).parent / "test_cli"
 
 
 def test_cli_help_backup_db():
-    """Test the CLI help output for ."""
+    """Test the CLI help output for backup_db."""
     # Capture standard output
     result = subprocess.run(['fastmigrate_backup_db', '--help'], 
                            capture_output=True, text=True)
     assert result.returncode == 0                           
     assert "usage: fastmigrate_backup_db [-h] [--db DB]" in result.stdout
+
+
+def test_cli_help_enroll_db():
+    """Test the CLI help output for enroll_db."""
+    # Capture standard output
+    result = subprocess.run(['fastmigrate_enroll_db', '--help'], 
+                           capture_output=True, text=True)
+    assert result.returncode == 0                           
+    assert "usage: fastmigrate_enroll_db [-h] [--db DB]" in result.stdout
 
 def test_cli_explicit_paths():
     """Test CLI with explicit path arguments."""
@@ -249,122 +258,252 @@ def test_cli_precedence():
         assert cursor.fetchone() is None, "CLI DB should not have config_table"
         
         conn_cli.close()
+
+
+def test_cli_enroll_db_success(tmp_path):
+    """Test the CLI enroll_db command successfully enrolls an unversioned database."""
+    db_path = tmp_path / "unversioned.db"
+    
+    # Create an unversioned database with a sample table
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO users (name) VALUES ('test_user')")
+    conn.commit()
+    conn.close()
+    
+    # Verify _meta table doesn't exist yet
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'")
+    assert cursor.fetchone() is None
+    conn.close()
+    
+    # Run the enroll_db command
+    result = subprocess.run([
+        "fastmigrate_enroll_db",
+        "--db", db_path,
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 0
+    
+    # Verify the database has been enrolled (_meta table created)
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'")
+    assert cursor.fetchone() is not None
+    
+    # Original data should still be intact
+    cursor = conn.execute("SELECT name FROM users WHERE name='test_user'")
+    assert cursor.fetchone() is not None
+    
+    # Version should be 0
+    cursor = conn.execute("SELECT version FROM _meta WHERE id = 1")
+    assert cursor.fetchone()[0] == 1
+    
+    conn.close()
+
+
+def test_cli_enroll_db_already_versioned(tmp_path):
+    """Test the CLI enroll_db command fails when the database is already versioned."""
+    db_path = tmp_path / "versioned.db"
+    
+    # Create a versioned database
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE _meta (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            version INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    conn.execute("INSERT INTO _meta (id, version) VALUES (1, 42)")
+    conn.commit()
+    conn.close()
+    
+    # Run the enroll_db command on an already versioned database
+    result = subprocess.run([
+        "fastmigrate_enroll_db",
+        "--db", db_path,
+    ], capture_output=True, text=True)
+    
+    # Should exit with zero status because the database is successfully versioned
+    assert result.returncode == 0
+    
+    # Verify the database version wasn't changed
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT version FROM _meta WHERE id = 1")
+    assert cursor.fetchone()[0] == 42
+    conn.close()
+
+
+def test_cli_enroll_db_nonexistent_db(tmp_path):
+    """Test the CLI enroll_db command fails when the database doesn't exist."""
+    db_path = tmp_path / "nonexistent.db"
+    
+    # Verify file doesn't exist
+    assert not db_path.exists()
+    
+    # Run the enroll_db command on a non-existent database
+    result = subprocess.run([
+        "fastmigrate_enroll_db",
+        "--db", db_path,
+    ], capture_output=True, text=True)
+    
+    # Should exit with non-zero status
+    assert result.returncode == 1
+    assert "does not exist" in result.stdout or "does not exist" in result.stderr
+
+
+def test_cli_enroll_db_invalid_db(tmp_path):
+    """Test the CLI enroll_db command fails when the database is invalid."""
+    db_path = tmp_path / "invalid.db"
+    
+    # Create an invalid database file
+    with open(db_path, 'wb') as f:
+        f.write(b'This is not a valid SQLite database')
+    
+    # Run the enroll_db command on an invalid database
+    result = subprocess.run([
+        "fastmigrate_enroll_db",
+        "--db", db_path
+    ], capture_output=True, text=True)
+    
+    # Should exit with non-zero status
+    assert result.returncode == 1
+
+
+def test_cli_enroll_db_with_config_file(tmp_path):
+    """Test the CLI enroll_db command with configuration from a file."""
+    db_path = tmp_path / "db_from_config.db"
+    config_path = tmp_path / "test_config.ini"
+    
+    # Create an unversioned database
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    
+    # Create a config file
+    config_path.write_text(f"[paths]\ndb = {db_path}")
+    
+    # Run the enroll_db command with config
+    result = subprocess.run([
+        "fastmigrate_enroll_db",
+        "--config", config_path,
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 0
+    
+    # Verify the database has been enrolled and increased in version
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT version FROM _meta WHERE id = 1")
+    assert cursor.fetchone()[0] == 1
+    conn.close()
         
 
-
-
-def test_cli_createdb_flag():
+def test_cli_createdb_flag(tmp_path):
     """Test the --create_db flag properly initializes a database with _meta table."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir_path = Path(temp_dir)
-        db_path = temp_dir_path / "new_db.db"
-        
-        # Verify the database doesn't exist yet
-        assert not db_path.exists()
-        
-        # Run the CLI with just the --create_db flag
-        result = subprocess.run([
-            "fastmigrate_create_db",
-            "--db", db_path,
-        ])
-        
-        assert result.returncode == 0
-        
-        # Verify database was created
-        assert db_path.exists()
-        
-        # Verify the _meta table exists with version 0
-        conn = sqlite3.connect(db_path)
-        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'")
-        assert cursor.fetchone() is not None
-        
-        cursor = conn.execute("SELECT version FROM _meta WHERE id = 1")
-        assert cursor.fetchone()[0] == 0
-        
-        conn.close()
+    db_path = tmp_path / "new_db.db"
+    
+    # Verify the database doesn't exist yet
+    assert not db_path.exists()
+    
+    # Run the CLI with just the --create_db flag
+    result = subprocess.run([
+        "fastmigrate_create_db",
+        "--db", db_path,
+    ])
+    
+    assert result.returncode == 0
+    
+    # Verify database was created
+    assert db_path.exists()
+    
+    # Verify the _meta table exists with version 0
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'")
+    assert cursor.fetchone() is not None
+    
+    cursor = conn.execute("SELECT version FROM _meta WHERE id = 1")
+    assert cursor.fetchone()[0] == 0
+    
+    conn.close()
 
 
-def test_check_db_version_option():
+def test_check_db_version_option(tmp_path):
     """Test the --check_db_version option correctly reports the database version."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir_path = Path(temp_dir)
-        db_path = temp_dir_path / "test.db"
-        
-        # Create database file with version 42
-        conn = sqlite3.connect(db_path)
-        conn.close()
-        _ensure_meta_table(db_path)
-        _set_db_version(db_path, 42)
-        
-        # Test with versioned database
-        result = subprocess.run([
-            "fastmigrate_check_version",
-            "--db", db_path
-        ], capture_output=True, text=True)
-        
-        assert result.returncode == 0
-        assert "Database version: 42" in result.stdout
-        
-        # Create unversioned database
-        unversioned_db = temp_dir_path / "unversioned.db"
-        conn = sqlite3.connect(unversioned_db)
-        conn.close()
-        
-        # Test with unversioned database
-        result = subprocess.run([
-            "fastmigrate_check_version",            
-            "--db", unversioned_db,
-        ], capture_output=True, text=True)
-        
-        assert result.returncode == 0
-        assert "unversioned" in result.stdout.lower()
-        
-        # Test with non-existent database
-        nonexistent_db = temp_dir_path / "nonexistent.db"
-        result = subprocess.run([
-            "fastmigrate_check_version",            
-            "--db", nonexistent_db,
-        ], capture_output=True, text=True)
-        
-        assert result.returncode == 1
-        assert "does not exist" in result.stdout
+    db_path = tmp_path / "test.db"
+    
+    # Create database file with version 42
+    conn = sqlite3.connect(db_path)
+    conn.close()
+    _ensure_meta_table(db_path)
+    _set_db_version(db_path, 42)
+    
+    # Test with versioned database
+    result = subprocess.run([
+        "fastmigrate_check_version",
+        "--db", db_path
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 0
+    assert "Database version: 42" in result.stdout
+    
+    # Create unversioned database
+    unversioned_db = tmp_path / "unversioned.db"
+    conn = sqlite3.connect(unversioned_db)
+    conn.close()
+    
+    # Test with unversioned database
+    result = subprocess.run([
+        "fastmigrate_check_version",            
+        "--db", unversioned_db,
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 0
+    assert "unversioned" in result.stdout.lower()
+    
+    # Test with non-existent database
+    nonexistent_db = tmp_path / "nonexistent.db"
+    result = subprocess.run([
+        "fastmigrate_check_version",            
+        "--db", nonexistent_db,
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 1
+    assert "does not exist" in result.stdout
 
 
-def test_cli_with_testsuite_a():
+def test_cli_with_testsuite_a(tmp_path):
     """Test CLI using testsuite_a."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir_path = Path(temp_dir)
-        db_path = temp_dir_path / "test.db"
-        
-        # Create empty database file
-        conn = sqlite3.connect(db_path)
-        conn.close()
-        
-        # Initialize the database with _meta table
-        _ensure_meta_table(db_path)
-        
-        # Run the CLI with explicit paths to the test suite
-        result = subprocess.run([
-            "fastmigrate_run_migrations",
-            "--db", db_path,
-            "--migrations", CLI_MIGRATIONS_DIR / "migrations"
-        ], capture_output=True, text=True)
-        
-        assert result.returncode == 0
-        
-        # Verify migrations applied
-        conn = sqlite3.connect(db_path)
-        
-        # Version should be 4 (all migrations applied)
-        cursor = conn.execute("SELECT version FROM _meta")
-        assert cursor.fetchone()[0] == 4
-        
-        # Verify tables exist
-        tables = ["users", "posts", "tags", "post_tags"]
-        for table in tables:
-            cursor = conn.execute(
-                f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table}'"
-            )
-            assert cursor.fetchone() is not None
-        
-        conn.close()
+    db_path = tmp_path / "test.db"
+    
+    # Create empty database file
+    conn = sqlite3.connect(db_path)
+    conn.close()
+    
+    # Initialize the database with _meta table
+    _ensure_meta_table(db_path)
+    
+    # Run the CLI with explicit paths to the test suite
+    result = subprocess.run([
+        "fastmigrate_run_migrations",
+        "--db", db_path,
+        "--migrations", CLI_MIGRATIONS_DIR / "migrations"
+    ], capture_output=True, text=True)
+    
+    assert result.returncode == 0
+    
+    # Verify migrations applied
+    conn = sqlite3.connect(db_path)
+    
+    # Version should be 4 (all migrations applied)
+    cursor = conn.execute("SELECT version FROM _meta")
+    assert cursor.fetchone()[0] == 4
+    
+    # Verify tables exist
+    tables = ["users", "posts", "tags", "post_tags"]
+    for table in tables:
+        cursor = conn.execute(
+            f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table}'"
+        )
+        assert cursor.fetchone() is not None
+    
+    conn.close()


### PR DESCRIPTION
This PR adds a CLI command for enrolling a DB, adding an initial migration in the process. 

- [x] Add CLI function for `enroll_db`, which adds the `_meta` versioning table, as well as including an initial migration called `0001-initial.sql`
- [x] Add tests
- [x] Passing tests
- [x] Document this change
- [x] Perform full lifecycle check of versioning and running migrations

